### PR TITLE
Prevent the pacman subprocess from receiving interruption signals from its parent, and kill signals from systemd

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Pacman Auto Update
+## Description
 
 Keeps packages from compiled repositories updated hourly.
 
@@ -21,14 +21,3 @@ Of the timer:
 ```sh
 systemctl list-timers pacman-auto-update
 ```
-
-## Credits
-
-For a list of contributors, in the application "terminal" type:
-
-> git clone https://github.com/cmuench/pacman-auto-update &> /dev/null; cd pacman-auto-update; git shortlog --summary --numbered --email; cd ..; rm -rf pacman-auto-update
-
-Part of the original source code was found at:
-
-https://www.techrapid.uk/2017/04/automatically-update-arch-linux-with-systemd.html
-

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Description
+# Pacman Auto Update
 
 Keeps packages from compiled repositories updated hourly.
 

--- a/root/usr/lib/pacman-auto-update/pacman-auto-update
+++ b/root/usr/lib/pacman-auto-update/pacman-auto-update
@@ -1,29 +1,130 @@
 #! /bin/bash
 
+verbose=0
+
 
 mainFunction () {
 	if ! connectionIsMetered && [[ ! -f "/var/lib/pacman/db.lck" ]]; then
-		sudo pacman --sync --refresh --sysupgrade --quiet --noconfirm
+		ifNotInterrupted downloadUpdates
+		ifNotInterrupted waitFor installUpdates
 	fi
+}
+
+
+checkPermissions () {
+	if [[ "$(id -u)" -ne 0 ]]; then
+		sudo "${0}"
+		exit "${?}"
+	fi
+}
+
+
+checkVerbose () {
+	if [[ "${verbose}" -ne 0 ]] && [[ "${verbose}" -ne 1 ]]; then
+		echo "Invalid verbose=${verbose}" >&2
+		echo "Verbose can either be 0 or 1"
+		exit 1
+	fi
+}
+
+
+configureTrap () {
+	interrupted=""
+	setTrap "nonCriticalTrap"
 }
 
 
 connectionIsMetered () {
-	if [[ -f "/usr/bin/nmcli" ]] &&
-	[[ ! -z "$(systemctl status NetworkManager | grep "running")" ]] &&
-	[[ ! -z "$(nmcli --terse --fields GENERAL.METERED dev show | grep "yes")" ]]; then
-		true
+	[[ -f "/usr/bin/nmcli" ]] &&
+	systemctl status NetworkManager | grep --quiet "running" &&
+	nmcli --terse --fields GENERAL.METERED dev show | grep --quiet "yes"
+}
+
+
+criticalTrap () {
+	nonCriticalTrap
+	printf "\n----Waiting for critical part to finish----\n" >&2
+}
+
+
+downloadUpdates () {
+	echo
+	echo "=== DOWNLOADING UPDATES ==="
+	pacman --sync --refresh --sysupgrade --downloadonly --quiet --noconfirm
+	echo
+}
+
+
+ifNotInterrupted () {
+	local command="${*}"
+
+	if [[ -z "${interrupted}" ]]; then
+		${command}
 	else
-		false
+		exit 0
 	fi
 }
 
 
+installUpdates () {
+	echo "=== INSTALLING UPDATES ==="
+	pacman --sync --refresh --sysupgrade --quiet --noconfirm
+	echo
+	
+	echo "=== PRUNING OLD CACHED PACKAGES ==="
+	paccache --remove --keep 3
+	echo
+}
+
+
+nonCriticalTrap () {
+	interrupted=1
+}
+
+
 prepareEnvironment () {
-	set -e
-	trap "" INT QUIT TERM EXIT
+	set -eum
+	configureTrap
+	checkPermissions
+	checkVerbose
+}
+
+
+setTrap () {
+	local operation="${*}"
+	# shellcheck disable=SC2064
+	trap "${operation}" ABRT ERR HUP INT QUIT TERM
+}
+
+
+silently () {
+	local commands="${*}"
+	
+	if [[ "${verbose}" -eq 0 ]]; then
+		${commands} 1>/dev/null
+	else
+		${commands}
+	fi
+}
+
+
+waitFor () {
+	local command="${*}"
+	
+	setTrap "criticalTrap"
+	${command} &
+	
+	while wait "${!}"; status="${?}"; [[ "${status}" -ge 128 ]]; do
+		sleep 1
+	done
+	
+	if [[ "${status}" -ne 0 ]]; then
+		exit "${status}"
+	fi
+	
+	setTrap "nonCriticalTrap"
 }
 
 
 prepareEnvironment
-mainFunction
+silently mainFunction

--- a/root/usr/lib/systemd/system/pacman-auto-update.service
+++ b/root/usr/lib/systemd/system/pacman-auto-update.service
@@ -6,7 +6,7 @@ After=network-online.target
 ExecStart=/usr/lib/pacman-auto-update/pacman-auto-update
 Nice=19
 KillMode=process
-KillSignal=SIGINT
+SendSIGKILL=no
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
@cmuench Lately I have learned quite a lot about a variety of ways processes can be terminated, and how to prevent critical processes to be the target of that. There's plenty of tricky details about it, here's a summary:

=== DISABLING INTERRUPTION SIGNALS ===

Prevents the pacman subprocess from receiving interruptions sent to its parent, by running it on a different process group not connected to the same terminal. Still retaining their family hierarchy.

This prevents pacman to override the traps from its parent, and disallow pacman to be interrupted in the middle of an update. Otherwise pacman on an interruption would finish copying the current package files to the filesystem, but it will skip post-install operations and installing further packages.

Since packages are compiled against specific versions of their dependencies shared objects, that can render those packages broken. This can prevent the system from being bootable.

=== DISABLING KILL SIGNALS ===

The systemd unit was configured to send an interruption signal only to its parent process in the case of a reboot.

Explicitly setting that signal to be an interruption was useless. As by default systemd sends a termination signal, which is alike and equally handled in the code.

Still systemd by default will send a second kill signal if the process continues running after a certain period of time. This last kill signal has been disabled.

=== DECOUPLING DOWNLOADING FROM INSTALLING ===

The download of updates is done separately, and can be instantly interrupted. So if the user reboots, the waiting time for pacman-auto-update to finish will be lower.

=== AUTO-PRUNING THE CACHE ===

Packages in the cache three versions older than the current installed one will be automatically removed.

=== ONLY OUTPUTS ON ERROR ===

Only info that would require attendance by a human will be output, aka errors.

For debugging all input can be enabled by setting the variable "verbose=1".

=== REMOVE CREDITS ===

Who contributed to the project is already provided by GitHub itself, on the project front page.

The original code no longer looks as the one in this repository, and its' actually dangerous. Anyone using the code provided on the original tutorial, and rebooting their systems during an update, can end with an unbootable system.