### PR TITLE
Terminate any leftover children + Don't warn on postponed update: Nothing abnormal

### DIFF
--- a/root/usr/lib/pacman-auto-update/pacman-auto-update
+++ b/root/usr/lib/pacman-auto-update/pacman-auto-update
@@ -10,6 +10,8 @@ mainFunction () {
 		updateKeyrings
 		updateSystem
 	fi
+
+	terminateChildren
 }
 
 
@@ -233,6 +235,11 @@ stringIsDate () {
 systemIsOutdated () {
 	so pacman --sync --refresh
 	[[ -n "$(pacman --query --upgrades 2> /dev/null || true)" ]]
+}
+
+
+terminateChildren () {
+	pkill -TERM -P $$ &>/dev/null || true
 }
 
 

--- a/root/usr/lib/pacman-auto-update/pacman-auto-update
+++ b/root/usr/lib/pacman-auto-update/pacman-auto-update
@@ -6,9 +6,7 @@ forceUpdate=0
 
 
 mainFunction () {
-	removeOrphanLock
-
-	if ! connectionIsMetered && ( systemIsOutdated || forcedUpdate ); then
+	if updatingIsFavorable && updatingIsNeeded; then
 		updateKeyrings
 		updateSystem
 	fi
@@ -113,6 +111,26 @@ nonCriticalTrap () {
 }
 
 
+ongoingInstallation () {
+	local lock="/var/lib/pacman/db.lck"
+
+	if [[ -f "${lock}" ]]; then
+		local modified; modified="$(stat --format=%Y "${lock}")"
+		local booted; booted="$(date --date="$(who --boot | cut --delimiter=" " --fields=13-)" +%s)"
+
+		if [[ $(( "${modified}" - "${booted}" )) -lt 0 ]] ||
+		[[ $(( "$(date +%s)" - "${modified}" )) -gt 86400 ]]; then
+			rm "${lock}"
+			false
+		else
+			true
+		fi
+	else
+		false
+	fi
+}
+
+
 packageInfo () {
 	local operation="${1}"
 	local package="${2}"
@@ -181,24 +199,6 @@ pruneOrphans () {
 }
 
 
-removeOrphanLock () {
-	local lock="/var/lib/pacman/db.lck"
-
-	if [[ -f "${lock}" ]]; then
-		local modified; modified="$(stat --format=%Y "${lock}")"
-		local booted; booted="$(date --date="$(who --boot | cut --delimiter=" " --fields=13-)" +%s)"
-
-		if [[ $(( "${modified}" - "${booted}" )) -lt 0 ]] ||
-		[[ $(( "$(date +%s)" - "${modified}" )) -gt 86400 ]]; then
-			rm "${lock}"
-		else
-			echo "Update postponed: The package database has a lock younger than a day, and older than boot time" >&2
-			exit 1
-		fi
-	fi
-}
-
-
 setTrap () {
 	local operation="${@}"
 	trap "${operation}" ABRT ERR HUP INT QUIT TERM
@@ -255,13 +255,23 @@ updateSystem () {
 }
 
 
+updatingIsFavorable () {
+	! ongoingInstallation && ! connectionIsMetered
+}
+
+
+updatingIsNeeded () {
+	systemIsOutdated || forcedUpdate
+}
+
+
 waitFor () {
 	local command="${@}"
 
 	setTrap "criticalTrap"
 	${command} &
 
-	while wait "${!}"; status="${?}"; [[ "${status}" -ge 128 ]]; do
+	while wait "$!"; status="$?"; [[ "${status}" -ge 128 ]]; do
 		sleep 1
 	done
 


### PR DESCRIPTION
Fixing the rest of issues we saw at https://github.com/cmuench/pacman-auto-update/issues/22.

The software will kill any leftover children still connected to the same terminal, even if they are in a forked process.

Also it won't report on postponed update, as there's nothing really wrong about it and it's solved automatically in any case.